### PR TITLE
Fix build when using "make --jobs"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,9 @@ SIGNER ?= 9ME8T34MPV
 PKG_CONFIG_PATH = $(BUILDPREFIX)/lib/pkgconfig
 export PKG_CONFIG_PATH
 
-default: clean dmg
+default:
+	$(MAKE) clean
+	$(MAKE) dmg
 
 clean:
 	git submodule foreach git clean -dfx


### PR DESCRIPTION
The default target does not depend on the two targets "clean" and "dmg".
The default target depends on "clean" first _then_ "dmg" after targets.

The code broke when "make --jobs" is used and the 2 targets are executed
simultaneously.

Also use "$(MAKE)" instead of "make" as documented in
https://www.gnu.org/software/make/manual/make.html#MAKE-Variable