### PR TITLE
Fix build when using "make --jobs"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,5 +61,9 @@ dmg: ccid-installer.dmg
 dmgsign: ccid-installer.dmg
 	codesign -s "$(SIGNER)" ccid-installer.dmg
 
-dist: clean signed dmg dmgsign
+dist:
+	$(MAKE) clean
+	$(MAKE) signed
+	$(MAKE) dmg
+	$(MAKE) dmgsign
 	cp ccid-installer.dmg ccid-installer-signed.dmg


### PR DESCRIPTION
The dist target does not depend on 4 other targets but on the execution
of the 4 targets in a sequence.

The code broke when "make --jobs" is used and the 2 targets are executed
simultaneously.